### PR TITLE
Enable dark mode in WinForms (controlled by system setting)

### DIFF
--- a/WC3LanGame/Network/NetworkScanner.cs
+++ b/WC3LanGame/Network/NetworkScanner.cs
@@ -36,8 +36,8 @@ namespace WC3LanGame.Network
         public static async Task<List<string>> ScanNetwork(UnicastIPAddressInformation ipAddress)
         {
             string network = ipAddress.Address + "/" + ipAddress.PrefixLength;
-            IPNetwork ipNetwork = IPNetwork.Parse(network);
-            string[] networkClientAddresses = ipNetwork.ListIPAddress(FilterEnum.Usable)
+            var ipNetwork = IPNetwork2.Parse(network);
+            string[] networkClientAddresses = ipNetwork.ListIPAddress(Filter.Usable)
                 .Select(ip => ip.ToString()).ToArray();
 
             List<string> activeClients = new List<string>();
@@ -76,8 +76,8 @@ namespace WC3LanGame.Network
             foreach (var localIp in localIpList)
             {
                 string network = localIp.Address + "/" + localIp.PrefixLength;
-                IPNetwork ipNetwork = IPNetwork.Parse(network);
-                var networkClientAddresses = ipNetwork.ListIPAddress(FilterEnum.Usable)
+                var ipNetwork = IPNetwork2.Parse(network);
+                var networkClientAddresses = ipNetwork.ListIPAddress(Filter.Usable)
                     .Select(ip => ip.ToString());
                 allNetworksClientAddresses.AddRange(networkClientAddresses);
             }

--- a/WC3LanGame/Program.cs
+++ b/WC3LanGame/Program.cs
@@ -11,6 +11,7 @@ namespace WC3LanGame
             // To customize application configuration such as set high DPI settings or default font,
             // see https://aka.ms/applicationconfiguration.
             ApplicationConfiguration.Initialize();
+            Application.SetColorMode(SystemColorMode.System);
             Application.Run(new MainForm());
         }
     }

--- a/WC3LanGame/WC3LanGame.csproj
+++ b/WC3LanGame/WC3LanGame.csproj
@@ -2,10 +2,12 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
     <ApplicationIcon>Resources\Warcraft.ico</ApplicationIcon>
+    <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IPNetwork2" Version="2.5.422" />
+    <PackageReference Include="IPNetwork2" Version="3.4.832" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
.NET 10.0 released with support for darkmode in winforms. This updates the application to build with .NET 10.0 and also adds the necessary call to enable it (based on system settings).
I also updated the version of IPNetwork2 package and made a couple tweaks because it had some API changes.
